### PR TITLE
Use full command line arg pgrep matching

### DIFF
--- a/secret-search
+++ b/secret-search
@@ -14,7 +14,7 @@ function cleanup() {
 trap cleanup EXIT
 
 # Find the PID
-if ! pid=`pgrep $1` ; then
+if ! pid=`pgrep -f -o $1` ; then
     echo "Unable to find PID for ${1}" >&2
     exit 1
 fi


### PR DESCRIPTION
The enarx-keepldr has been updated to insert its own
image name into the command line arguments in the event
that the nil backend is selected.

Interestingly enough, pgrep won't find this if the
image name is too long. This is a hurdle I ran into when
re-doing the demo videos.

Use the -f option to have it match on the entire command
line so that it will find the process and use the -o option
(which is kinda kludgy) to have it match on the "oldest"
process (otherwise we may accidentally match on the pgrep's
command line by accident). The oldest process will be the
keepldr as it waits for input.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
